### PR TITLE
Zoom into cards

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -373,7 +373,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2779b23bfeb3c7f4a8183e0a7460fa6a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  board: {fileID: 711624502}
 --- !u!1 &222865688
 GameObject:
   m_ObjectHideFlags: 0
@@ -677,7 +676,6 @@ GameObject:
   - component: {fileID: 836102267}
   - component: {fileID: 836102269}
   - component: {fileID: 836102270}
-  - component: {fileID: 836102272}
   - component: {fileID: 836102268}
   m_Layer: 5
   m_Name: Heap
@@ -766,18 +764,6 @@ MonoBehaviour:
   m_Spacing: {x: -103, y: 0}
   m_Constraint: 2
   m_ConstraintCount: 1
---- !u!114 &836102272
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 836102266}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7111b790d22304a128afc7b728a1c2e3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &847474006
 GameObject:
   m_ObjectHideFlags: 0
@@ -899,7 +885,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1198803622}
   - component: {fileID: 1198803624}
-  - component: {fileID: 1198803625}
   m_Layer: 5
   m_Name: Stack
   m_TagString: Untagged
@@ -934,18 +919,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1198803621}
   m_CullTransparentMesh: 0
---- !u!114 &1198803625
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1198803621}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00128c1dbdc474e81a9df0547eaba73d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1261533424
 GameObject:
   m_ObjectHideFlags: 0
@@ -1343,7 +1316,6 @@ GameObject:
   - component: {fileID: 1940409407}
   - component: {fileID: 1940409406}
   - component: {fileID: 1940409408}
-  - component: {fileID: 1940409411}
   m_Layer: 5
   m_Name: Grip
   m_TagString: Untagged
@@ -1432,18 +1404,6 @@ MonoBehaviour:
   m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
---- !u!114 &1940409411
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1940409404}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3b7d49baef6c147ffbaecc1b20ae5144, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1942180166
 GameObject:
   m_ObjectHideFlags: 0
@@ -1726,7 +1686,6 @@ GameObject:
   - component: {fileID: 2117212074}
   - component: {fileID: 2117212075}
   - component: {fileID: 2117212076}
-  - component: {fileID: 2117212077}
   - component: {fileID: 2117212078}
   m_Layer: 5
   m_Name: Rig
@@ -1791,18 +1750,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &2117212077
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2117212073}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 719fad782f42f394fbde013a198da790, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &2117212078
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Config/GameConfig.cs
+++ b/Assets/Scripts/Config/GameConfig.cs
@@ -12,8 +12,9 @@ public class GameConfig : MonoBehaviour
     void Start()
     {
         var board = GameObject.Find("/Board");
-        var zoom = new CardZoom(board);
-        var parts = new BoardParts(board, zoom);
+        var perception = new RunnerPerception();
+        var zoom = new CardZoom(board, perception);
+        var parts = new BoardParts(board, perception, zoom);
         var corpPlayer = new Player(
             deck: new Decks().DemoCorp(),
             pilot: new CorpAi(new System.Random(1234))
@@ -22,10 +23,10 @@ public class GameConfig : MonoBehaviour
             deck: new Decks().DemoRunner(),
             pilot: new CardPickingPilot(
                 new CardChoiceScreen(parts),
-                new AutoPaidWindowPilot(
-                    new SingleChoiceMaker(
-                        new TrashingPilot(
-                            new TrashChoiceScreen(parts),
+                new TrashingPilot(
+                    new TrashChoiceScreen(parts),
+                    new AutoPaidWindowPilot(
+                        new SingleChoiceMaker(
                             new NoPilot()
                         )
                     )

--- a/Assets/Scripts/Config/GameConfig.cs
+++ b/Assets/Scripts/Config/GameConfig.cs
@@ -5,14 +5,15 @@ using model.ai;
 using view.log;
 using model.player;
 using model.zones;
+using view;
 
 public class GameConfig : MonoBehaviour
 {
-    public GameObject board;
-    private Game game;
-
-    void Awake()
+    void Start()
     {
+        var board = GameObject.Find("/Board");
+        var zoom = new CardZoom(board);
+        var parts = new BoardParts(board, zoom);
         var corpPlayer = new Player(
             deck: new Decks().DemoCorp(),
             pilot: new CorpAi(new System.Random(1234))
@@ -20,28 +21,24 @@ public class GameConfig : MonoBehaviour
         var runnerPlayer = new Player(
             deck: new Decks().DemoRunner(),
             pilot: new CardPickingPilot(
-                new CardChoiceScreen(board),
+                new CardChoiceScreen(parts),
                 new AutoPaidWindowPilot(
                     new SingleChoiceMaker(
                         new TrashingPilot(
-                            new TrashChoiceScreen(board),
+                            new TrashChoiceScreen(parts),
                             new NoPilot()
                         )
                     )
                 )
             )
         );
-        game = new Game(corpPlayer, runnerPlayer, new Shuffling(10006));
-    }
-
-    void Start()
-    {
+        var game = new Game(corpPlayer, runnerPlayer, new Shuffling(10006));
         var flowView = new GameFlowView();
         var flowLog = new GameFlowLog();
         flowView.Display(board, game);
         flowLog.Display(game);
-        var corpView = new CorpViewConfig().Display(game);
-        new RunnerViewConfig().Display(game, corpView);
+        var corpView = new CorpViewConfig().Display(game, parts);
+        new RunnerViewConfig().Display(game, corpView, parts);
         game.Start();
     }
 }

--- a/Assets/Scripts/Controller/CardInspection.cs
+++ b/Assets/Scripts/Controller/CardInspection.cs
@@ -1,0 +1,25 @@
+﻿using model.cards;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using view.gui;
+
+namespace controller
+{
+    public class CardInspection : MonoBehaviour, IPointerClickHandler
+    {
+        private CardZoom zoom;
+        private Card card;
+
+        public CardInspection Represent(CardZoom zoom, Card card)
+        {
+            this.zoom = zoom;
+            this.card = card;
+            return this;
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            zoom.Show(card);
+        }
+    }
+}

--- a/Assets/Scripts/Controller/CardInspection.cs.meta
+++ b/Assets/Scripts/Controller/CardInspection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6464ad92010f95642ab28812c0a152b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Controller/CardUnzoom.cs
+++ b/Assets/Scripts/Controller/CardUnzoom.cs
@@ -1,0 +1,20 @@
+﻿using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace controller
+{
+    public class CardUnzoom : MonoBehaviour, IPointerClickHandler
+    {
+        private GameObject zoom;
+        public CardUnzoom Construct(GameObject zoom)
+        {
+            this.zoom = zoom;
+            return this;
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            zoom.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/Controller/CardUnzoom.cs.meta
+++ b/Assets/Scripts/Controller/CardUnzoom.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb8d426dfd733be4fb64c78fbf7a4b30
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Model/Corp.cs
+++ b/Assets/Scripts/Model/Corp.cs
@@ -40,6 +40,7 @@ namespace model
 
         public void Start(Game game)
         {
+            identity.FlipFaceUp();
             pilot.Play(game);
             credits.Gain(5);
             zones.rd.Shuffle();

--- a/Assets/Scripts/Model/Player/Information.cs
+++ b/Assets/Scripts/Model/Player/Information.cs
@@ -1,0 +1,74 @@
+﻿namespace model.player
+{
+    // CR: 10.2
+    public enum Information
+    {
+        // CR: 10.2.2
+        HIDDEN_FROM_ALL,
+        HIDDEN_FROM_CORP,
+        HIDDEN_FROM_RUNNER,
+        // CR: 10.2.3
+        OPEN
+    }
+
+    // CR: 10.2.2
+    // CR: 10.2.3
+    public interface IPerception
+    {
+        bool CanSee(Information information);
+    }
+
+    public class CorpPerception : IPerception
+    {
+        bool IPerception.CanSee(Information information)
+        {
+            switch (information)
+            {
+                case Information.OPEN:
+                case Information.HIDDEN_FROM_RUNNER:
+                    return true;
+                case Information.HIDDEN_FROM_ALL:
+                case Information.HIDDEN_FROM_CORP:
+                    return false;
+                default:
+                    throw new System.ArgumentException(information.ToString());
+            }
+        }
+    }
+
+    public class RunnerPerception : IPerception
+    {
+        bool IPerception.CanSee(Information information)
+        {
+            switch (information)
+            {
+                case Information.OPEN:
+                case Information.HIDDEN_FROM_CORP:
+                    return true;
+                case Information.HIDDEN_FROM_ALL:
+                case Information.HIDDEN_FROM_RUNNER:
+                    return false;
+                default:
+                    throw new System.ArgumentException(information.ToString());
+            }
+        }
+    }
+
+    public class SpectatorPerception : IPerception
+    {
+        bool IPerception.CanSee(Information information)
+        {
+            switch (information)
+            {
+                case Information.OPEN:
+                    return true;
+                case Information.HIDDEN_FROM_ALL:
+                case Information.HIDDEN_FROM_RUNNER:
+                case Information.HIDDEN_FROM_CORP:
+                    return false;
+                default:
+                    throw new System.ArgumentException(information.ToString());
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Model/Player/Information.cs.meta
+++ b/Assets/Scripts/Model/Player/Information.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7c2b519b6aad1f4482db1813a7513fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Model/Runner.cs
+++ b/Assets/Scripts/Model/Runner.cs
@@ -45,6 +45,7 @@ namespace model
 
         public void Start(Game game)
         {
+            identity.FlipFaceUp();
             pilot.Play(game);
             credits.Gain(5);
             zones.stack.Shuffle();

--- a/Assets/Scripts/Model/Timing/AccessCard.cs
+++ b/Assets/Scripts/Model/Timing/AccessCard.cs
@@ -1,5 +1,6 @@
 ﻿using model.cards;
-using model.zones.corp;
+using model.player;
+using model.zones;
 using System.Threading.Tasks;
 
 namespace model.timing
@@ -17,12 +18,22 @@ namespace model.timing
 
         async public Task AwaitEnd()
         {
+            var preAccessInfo = Look();
+            var preAccessZone = card.Zone;
             await TriggerAccessingCard(); // 7.8.1
             await game.Checkpoint(); // 7.8.2
             await Trash(); // 7.8.3
             await Steal(); // 7.8.4
             await TriggerAfterAccessingCard(); // 7.8.5
             await game.Checkpoint(); // 7.8.6
+            StopLooking(preAccessInfo, preAccessZone);
+        }
+
+        private Information Look()
+        {
+            var info = card.Information;
+            card.UpdateInfo(Information.OPEN); // TODO actually, Corp shouldn't see this in R&D
+            return info;
         }
 
         async private Task TriggerAccessingCard()
@@ -59,6 +70,14 @@ namespace model.timing
         async private Task TriggerAfterAccessingCard()
         {
             await Task.CompletedTask; // TODO
+        }
+
+        private void StopLooking(Information preAccessInfo, Zone preAccessZone)
+        {
+            if (card.Zone == preAccessZone)
+            {
+                card.UpdateInfo(preAccessInfo);
+            }
         }
 
         public override string ToString()

--- a/Assets/Scripts/Model/Zones/Runner/Grip.cs
+++ b/Assets/Scripts/Model/Zones/Runner/Grip.cs
@@ -1,15 +1,21 @@
 ﻿using model.cards;
+using model.player;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace model.zones.runner
 {
-    public class Grip
+    public class Grip : IZoneAdditionObserver
     {
         public readonly Zone zone = new Zone("Grip");
         private HashSet<IGripDiscardObserver> discards = new HashSet<IGripDiscardObserver>();
         private TaskCompletionSource<bool> discarded;
+
+        public Grip()
+        {
+            zone.ObserveAdditions(this);
+        }
 
         async public Task Discard()
         {
@@ -41,6 +47,11 @@ namespace model.zones.runner
         public void UnobserveDiscarding(IGripDiscardObserver observer)
         {
             discards.Remove(observer);
+        }
+
+        void IZoneAdditionObserver.NotifyCardAdded(Card card)
+        {
+            card.UpdateInfo(Information.HIDDEN_FROM_CORP);
         }
     }
 

--- a/Assets/Scripts/View/BoardParts.cs
+++ b/Assets/Scripts/View/BoardParts.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using model.player;
+using UnityEngine;
 using view.gui;
 
 namespace view
@@ -6,17 +7,19 @@ namespace view
     public class BoardParts
     {
         public GameObject board;
+        private IPerception perception;
         private CardZoom zoom;
 
-        public BoardParts(GameObject board, CardZoom zoom)
+        public BoardParts(GameObject board, IPerception perception, CardZoom zoom)
         {
             this.board = board;
+            this.perception = perception;
             this.zoom = zoom;
         }
 
         public CardPrinter Print(GameObject parent)
         {
-            return new CardPrinter(parent, zoom);
+            return new CardPrinter(parent, perception, zoom);
         }
     }
 }

--- a/Assets/Scripts/View/BoardParts.cs
+++ b/Assets/Scripts/View/BoardParts.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+using view.gui;
+
+namespace view
+{
+    public class BoardParts
+    {
+        public GameObject board;
+        private CardZoom zoom;
+
+        public BoardParts(GameObject board, CardZoom zoom)
+        {
+            this.board = board;
+            this.zoom = zoom;
+        }
+
+        public CardPrinter Print(GameObject parent)
+        {
+            return new CardPrinter(parent, zoom);
+        }
+    }
+}

--- a/Assets/Scripts/View/BoardParts.cs.meta
+++ b/Assets/Scripts/View/BoardParts.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93c9f20bc9761cd47add65fd73cf1ac7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/View/CardPrinter.cs
+++ b/Assets/Scripts/View/CardPrinter.cs
@@ -2,12 +2,22 @@
 using UnityEngine.UI;
 using model.cards;
 using model;
+using controller;
+using view.gui;
 
 namespace view
 {
-    public class CardPrinter : MonoBehaviour
+    public class CardPrinter
     {
+        private RawCardPrinter raw;
+        private CardZoom zoom;
         public bool Sideways = false;
+
+        public CardPrinter(GameObject parent, CardZoom zoom)
+        {
+            this.raw = new RawCardPrinter(parent);
+            this.zoom = zoom;
+        }
 
         public GameObject PrintCorpFacedown(string name)
         {
@@ -21,15 +31,17 @@ namespace view
 
         public GameObject PrintFlippable(Card card)
         {
-            return Print(card.Name, FaceSprites.ChooseFace(card))
-                .AddComponent<PrintedCard>()
-                .Represent(card, Sideways)
-                .gameObject;
+            var gameObject = Print(card.Name, FaceSprites.ChooseFace(card));
+            gameObject.AddComponent<PrintedCard>().Represent(card, Sideways);
+            gameObject.AddComponent<CardInspection>().Represent(zoom, card);
+            return gameObject;
         }
 
         public GameObject Print(Card card)
         {
-            return Print(card.Name, "Images/Cards/" + card.FaceupArt);
+            var gameObject = Print(card.Name, "Images/Cards/" + card.FaceupArt);
+            gameObject.AddComponent<CardInspection>().Represent(zoom, card);
+            return gameObject;
         }
 
         public GameObject Print(string name, string asset)
@@ -39,20 +51,7 @@ namespace view
 
         private GameObject Print(string name, Sprite sprite)
         {
-            var card = new GameObject(name)
-            {
-                layer = 5
-            };
-            var image = card.AddComponent<Image>();
-            image.sprite = sprite;
-            image.preserveAspect = true;
-            card.transform.SetParent(transform);
-            var rectangle = image.rectTransform;
-            rectangle.anchorMin = new Vector2(0.1f, 0.1f);
-            rectangle.anchorMax = new Vector2(0.9f, 0.9f);
-            rectangle.offsetMin = Vector2.zero;
-            rectangle.offsetMax = Vector2.zero;
-            return card;
+            return raw.Print(name, sprite);
         }
 
         private class PrintedCard : MonoBehaviour, IFlipObserver
@@ -98,6 +97,35 @@ namespace view
             }
         }
     }
+
+    public class RawCardPrinter
+    {
+        private GameObject parent;
+
+        public RawCardPrinter(GameObject parent)
+        {
+            this.parent = parent;
+        }
+
+        public GameObject Print(string name, Sprite sprite)
+        {
+            var card = new GameObject(name)
+            {
+                layer = 5
+            };
+            var image = card.AddComponent<Image>();
+            image.sprite = sprite;
+            image.preserveAspect = true;
+            card.transform.SetParent(parent.transform);
+            var rectangle = image.rectTransform;
+            rectangle.anchorMin = new Vector2(0.1f, 0.1f);
+            rectangle.anchorMax = new Vector2(0.9f, 0.9f);
+            rectangle.offsetMin = Vector2.zero;
+            rectangle.offsetMax = Vector2.zero;
+            return card;
+        }
+    }
+
 
     class FaceSprites
     {

--- a/Assets/Scripts/View/GUI/CardChoiceScreen.cs
+++ b/Assets/Scripts/View/GUI/CardChoiceScreen.cs
@@ -17,11 +17,11 @@ namespace view.gui
         private CardPrinter optionsRow;
         private IDictionary<Card, GameObject> visuals = new Dictionary<Card, GameObject>();
 
-        public CardChoiceScreen(GameObject board)
+        public CardChoiceScreen(BoardParts parts)
         {
-            blanket = CreateBlanket(board);
-            subjectRow = CreateSubjectRow(blanket);
-            optionsRow = CreateOptionsRow(blanket);
+            blanket = CreateBlanket(parts.board);
+            subjectRow = CreateSubjectRow(blanket, parts);
+            optionsRow = CreateOptionsRow(blanket, parts);
         }
 
         private GameObject CreateBlanket(GameObject board)
@@ -42,7 +42,7 @@ namespace view.gui
             return blanket;
         }
 
-        private CardPrinter CreateSubjectRow(GameObject blanket)
+        private CardPrinter CreateSubjectRow(GameObject blanket, BoardParts parts)
         {
             var subjectRow = new GameObject("Subject row")
             {
@@ -54,11 +54,11 @@ namespace view.gui
             rectangle.anchorMax = new Vector2(0.9f, 1.0f);
             rectangle.offsetMin = Vector2.zero;
             rectangle.offsetMax = Vector2.zero;
-            return subjectRow.AddComponent<CardPrinter>();
+            return parts.Print(subjectRow);
         }
 
 
-        private CardPrinter CreateOptionsRow(GameObject blanket)
+        private CardPrinter CreateOptionsRow(GameObject blanket, BoardParts parts)
         {
             var optionsRow = new GameObject("Options row")
             {
@@ -72,7 +72,7 @@ namespace view.gui
             rectangle.offsetMax = Vector2.zero;
             var horizontalLayout = optionsRow.AddComponent<HorizontalLayoutGroup>();
             horizontalLayout.spacing = 200;
-            return optionsRow.AddComponent<CardPrinter>();
+            return parts.Print(optionsRow);
         }
 
         async Task<Card> IDecision<string, Card>.Declare(string q, IEnumerable<Card> options, Game game)

--- a/Assets/Scripts/View/GUI/CardZoom.cs
+++ b/Assets/Scripts/View/GUI/CardZoom.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using controller;
+using model;
+using model.cards;
+using model.choices;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace view.gui
+{
+    public class CardZoom
+    {
+        private GameObject blanket;
+        private RawCardPrinter rawCardPrinter;
+
+        public CardZoom(GameObject board)
+        {
+            blanket = CreateBlanket(board);
+            rawCardPrinter = new RawCardPrinter(blanket);
+        }
+
+        private GameObject CreateBlanket(GameObject board)
+        {
+            var blanket = new GameObject("Card zoom")
+            {
+                layer = 5
+            };
+            blanket.SetActive(false);
+            var image = blanket.AddComponent<Image>();
+            image.color = new Color(0, 0, 0, 0.5f);
+            blanket.transform.SetParent(board.transform);
+            var rectangle = image.rectTransform;
+            rectangle.anchorMin = new Vector2(0.00f, 0.00f);
+            rectangle.anchorMax = new Vector2(0.40f, 1.00f);
+            rectangle.offsetMin = Vector2.zero;
+            rectangle.offsetMax = Vector2.zero;
+            return blanket;
+        }
+
+        internal void Show(Card card)
+        {
+            blanket.SetActive(true);
+            blanket.transform.SetAsLastSibling();
+            rawCardPrinter.Print("Zoomed in " + card.Name, Resources.Load<Sprite>("Images/Cards/" + card.FaceupArt));
+        }
+    }
+}

--- a/Assets/Scripts/View/GUI/CardZoom.cs
+++ b/Assets/Scripts/View/GUI/CardZoom.cs
@@ -1,4 +1,5 @@
-﻿using model.cards;
+﻿using controller;
+using model.cards;
 using model.player;
 using UnityEngine;
 using UnityEngine.UI;
@@ -45,6 +46,7 @@ namespace view.gui
             blanket.SetActive(true);
             blanket.transform.SetAsLastSibling();
             zoomed = rawCardPrinter.Print("Zoomed in " + card.Name, FaceSprites.ChooseFace(card, perception));
+            zoomed.AddComponent<CardUnzoom>().Construct(blanket);
         }
     }
 }

--- a/Assets/Scripts/View/GUI/CardZoom.cs
+++ b/Assets/Scripts/View/GUI/CardZoom.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using controller;
-using model;
-using model.cards;
-using model.choices;
+﻿using model.cards;
+using model.player;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -15,9 +9,12 @@ namespace view.gui
     {
         private GameObject blanket;
         private RawCardPrinter rawCardPrinter;
+        private IPerception perception;
+        private GameObject zoomed;
 
-        public CardZoom(GameObject board)
+        public CardZoom(GameObject board, IPerception perception)
         {
+            this.perception = perception;
             blanket = CreateBlanket(board);
             rawCardPrinter = new RawCardPrinter(blanket);
         }
@@ -42,9 +39,12 @@ namespace view.gui
 
         internal void Show(Card card)
         {
+            if (zoomed != null) {
+                Object.Destroy(zoomed);
+            }
             blanket.SetActive(true);
             blanket.transform.SetAsLastSibling();
-            rawCardPrinter.Print("Zoomed in " + card.Name, Resources.Load<Sprite>("Images/Cards/" + card.FaceupArt));
+            zoomed = rawCardPrinter.Print("Zoomed in " + card.Name, FaceSprites.ChooseFace(card, perception));
         }
     }
 }

--- a/Assets/Scripts/View/GUI/CardZoom.cs.meta
+++ b/Assets/Scripts/View/GUI/CardZoom.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8fb1296471d8c644bd9b1bdf1878323
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/View/GUI/CorpViewConfig.cs
+++ b/Assets/Scripts/View/GUI/CorpViewConfig.cs
@@ -5,12 +5,11 @@ namespace view.gui
 {
     public class CorpViewConfig
     {
-        public CorpView Display(Game game)
+        public CorpView Display(Game game, BoardParts parts)
         {
             var zones = game.corp.zones;
             game.corp.credits.Observe(GameObject.Find("Corp/Credits/Credits text").AddComponent<CreditPoolText>());
-            var servers = GameObject.Find("Servers").AddComponent<ServerRow>();
-            servers.Represent(zones);
+            var servers = new ServerRow(GameObject.Find("Servers"), parts, zones);
             var archivesBox = servers.Box(zones.archives);
             archivesBox.Printer.Sideways = true;
             var rd = servers.Box(zones.rd).Printer.PrintCorpFacedown("Top of R&D");

--- a/Assets/Scripts/View/GUI/GripFan.cs
+++ b/Assets/Scripts/View/GUI/GripFan.cs
@@ -3,31 +3,33 @@ using controller;
 using model.cards;
 using model;
 using System.Collections.Generic;
-using model.zones.runner;
 using model.zones;
 
 namespace view.gui
 {
-    public class GripFan : MonoBehaviour, IZoneAdditionObserver, IZoneRemovalObserver
+    public class GripFan : IZoneAdditionObserver, IZoneRemovalObserver
     {
+        private GameObject gameObject;
         private Game game;
         private DropZone playZone;
         private DropZone rigZone;
         private DropZone heapZone;
+        private CardZoom zoom;
         private Dictionary<Card, GameObject> visuals = new Dictionary<Card, GameObject>();
         private CardPrinter printer;
+        public DropZone DropZone { get; private set; }
 
-        public void Construct(Game game, DropZone playZone, DropZone rigZone, DropZone heapZone)
+        public GripFan(GameObject gameObject, Game game, DropZone playZone, DropZone rigZone, DropZone heapZone, BoardParts parts)
         {
+            this.gameObject = gameObject;
             this.game = game;
             this.playZone = playZone;
             this.rigZone = rigZone;
             this.heapZone = heapZone;
-        }
-
-        void Awake()
-        {
-            printer = gameObject.AddComponent<CardPrinter>();
+            this.printer = parts.Print(gameObject);
+            this.DropZone = gameObject.AddComponent<DropZone>();
+            game.runner.zones.grip.zone.ObserveAdditions(this);
+            game.runner.zones.grip.zone.ObserveRemovals(this);
         }
 
         void IZoneAdditionObserver.NotifyCardAdded(Card card)
@@ -67,7 +69,7 @@ namespace view.gui
 
         void IZoneRemovalObserver.NotifyCardRemoved(Card card)
         {
-            Destroy(visuals[card]);
+            Object.Destroy(visuals[card]);
             visuals.Remove(card);
         }
     }

--- a/Assets/Scripts/View/GUI/HeapPile.cs
+++ b/Assets/Scripts/View/GUI/HeapPile.cs
@@ -1,20 +1,28 @@
 ﻿using UnityEngine;
 using model.cards;
-using model.zones.runner;
 using model.zones;
+using controller;
+using model;
 
 namespace view.gui
 {
-    public class HeapPile : MonoBehaviour, IZoneAdditionObserver
+    public class HeapPile : IZoneAdditionObserver
     {
-        void Start()
+        private GameObject gameObject;
+        private CardPrinter printer;
+        public DropZone DropZone { get; private set; }
+
+        public HeapPile(GameObject gameObject, Game game, BoardParts parts)
         {
-            gameObject.AddComponent<CardPrinter>();
+            this.gameObject = gameObject;
+            this.printer = parts.Print(gameObject);
+            this.DropZone = gameObject.AddComponent<DropZone>();
+            game.runner.zones.heap.zone.ObserveAdditions(this);
         }
 
         void IZoneAdditionObserver.NotifyCardAdded(Card card)
         {
-            GetComponent<CardPrinter>().Print(card);
+            printer.Print(card);
         }
     }
 }

--- a/Assets/Scripts/View/GUI/RigGrid.cs
+++ b/Assets/Scripts/View/GUI/RigGrid.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEngine;
 using model.cards;
-using model.zones.runner;
 using System.Collections.Generic;
 using model.play;
 using controller;
@@ -10,27 +9,25 @@ using model.zones;
 
 namespace view.gui
 {
-    public class RigGrid : MonoBehaviour, IZoneAdditionObserver, IZoneRemovalObserver, IPaidAbilityObserver
+    public class RigGrid : IZoneAdditionObserver, IZoneRemovalObserver, IPaidAbilityObserver
     {
         private Game game;
-        private DropZone playZone;
+
+        public DropZone playZone;
+        public DropZone DropZone { get; private set; }
         private Dictionary<Card, GameObject> visuals = new Dictionary<Card, GameObject>();
         private CardPrinter printer;
 
-        public void Construct(Game game, DropZone playZone)
+        public RigGrid(GameObject gameObject, Game game, DropZone playZone, BoardParts parts)
         {
             this.game = game;
             this.playZone = playZone;
+            this.printer = parts.Print(gameObject);
             game.runner.paidWindow.ObserveAbility(this);
             game.runner.zones.rig.zone.ObserveAdditions(this);
             game.runner.zones.rig.zone.ObserveRemovals(this);
+            this.DropZone = gameObject.AddComponent<DropZone>();
         }
-
-        void Awake()
-        {
-            printer = gameObject.AddComponent<CardPrinter>();
-        }
-
         void IZoneAdditionObserver.NotifyCardAdded(Card card)
         {
             var visual = printer.Print(card);
@@ -39,7 +36,7 @@ namespace view.gui
 
         void IZoneRemovalObserver.NotifyCardRemoved(Card card)
         {
-            Destroy(visuals[card]);
+            Object.Destroy(visuals[card]);
         }
 
         void IPaidAbilityObserver.NotifyPaidAbilityAvailable(Ability ability, Card source)

--- a/Assets/Scripts/View/GUI/RunnerViewConfig.cs
+++ b/Assets/Scripts/View/GUI/RunnerViewConfig.cs
@@ -6,20 +6,15 @@ namespace view.gui
 {
     public class RunnerViewConfig
     {
-        public void Display(Game game, CorpView corpView)
+        public void Display(Game game, CorpView corpView, BoardParts parts)
         {
-            GripFan grip = Object.FindObjectOfType<GripFan>();
-            StackPile stackPile = Object.FindObjectOfType<StackPile>();
-            RigGrid rig = Object.FindObjectOfType<RigGrid>();
             var playZone = GameObject.Find("Trigger").AddComponent<DropZone>();
-            var rigZone = GameObject.Find("Rig").AddComponent<DropZone>();
-            var heapZone = GameObject.Find("Heap").AddComponent<DropZone>();
-            var gripZone = GameObject.Find("Grip").AddComponent<DropZone>();
-            new ZoneBox(GameObject.Find("Runner/Left hand/Score")).Represent(game.runner.zones.score.zone);
-            grip.Construct(game, playZone, rigZone, heapZone);
-            stackPile.Construct(game, gripZone);
-            rig.Construct(game, playZone);
-            GameObject.Find("Runner/Right hand/Core/Identity").AddComponent<CardPrinter>().Print(game.runner.identity);
+            RigGrid rigGrid = new RigGrid(GameObject.Find("Rig"), game, playZone, parts);
+            HeapPile heapPile = new HeapPile(GameObject.Find("Heap"), game, parts);
+            GripFan gripFan = new GripFan(GameObject.Find("Grip"), game, playZone, rigGrid.DropZone, heapPile.DropZone, parts);
+            StackPile stackPile = new StackPile(GameObject.Find("Stack"), game, gripFan.DropZone, parts);
+            new ZoneBox(GameObject.Find("Runner/Left hand/Score"), parts).Represent(game.runner.zones.score.zone);
+            parts.Print(GameObject.Find("Runner/Right hand/Core/Identity")).Print(game.runner.identity);
             new RunInitiation(
                 gameObject: GameObject.Find("Runner/Activation/Run"),
                 serverRow: corpView.serverRow,
@@ -34,12 +29,6 @@ namespace view.gui
                 );
 
             game.runner.credits.Observe(GameObject.Find("Runner/Right hand/Credits/Credits text").AddComponent<CreditPoolText>());
-            var zones = game.runner.zones;
-            zones.stack.zone.ObserveCount(stackPile.gameObject.AddComponent<PileCount>());
-            zones.stack.zone.ObserveCount(stackPile);
-            zones.grip.zone.ObserveAdditions(grip);
-            zones.grip.zone.ObserveRemovals(grip);
-            zones.heap.zone.ObserveAdditions(Object.FindObjectOfType<HeapPile>());
         }
     }
 }

--- a/Assets/Scripts/View/GUI/ServerBox.cs
+++ b/Assets/Scripts/View/GUI/ServerBox.cs
@@ -27,7 +27,7 @@ namespace view.gui
 
         void IZoneAdditionObserver.NotifyCardAdded(Card card)
         {
-            var printedCard = Printer.PrintFlippable(card);
+            var printedCard = Printer.Print(card);
             visuals[card] = printedCard;
         }
 

--- a/Assets/Scripts/View/GUI/ServerBox.cs
+++ b/Assets/Scripts/View/GUI/ServerBox.cs
@@ -14,7 +14,7 @@ namespace view.gui
         public CardPrinter Printer { get; private set; }
         private IDictionary<Card, GameObject> visuals = new Dictionary<Card, GameObject>();
 
-        public ServerBox(GameObject gameObject, IServer server)
+        public ServerBox(GameObject gameObject, IServer server, BoardParts parts)
         {
             this.gameObject = gameObject;
             this.server = server;
@@ -22,7 +22,7 @@ namespace view.gui
             image.sprite = Resources.Load<Sprite>("Images/UI/9slice-solid-white");
             image.type = Image.Type.Sliced;
             image.fillCenter = false;
-            Printer = gameObject.AddComponent<CardPrinter>();
+            Printer = parts.Print(gameObject);
         }
 
         void IZoneAdditionObserver.NotifyCardAdded(Card card)

--- a/Assets/Scripts/View/GUI/StackPile.cs
+++ b/Assets/Scripts/View/GUI/StackPile.cs
@@ -1,26 +1,21 @@
 ﻿using UnityEngine;
 using controller;
 using model;
-using model.zones.runner;
 using model.zones;
 
 namespace view.gui
 {
-    public class StackPile : MonoBehaviour, IZoneCountObserver
+    public class StackPile : IZoneCountObserver
     {
         private Game game;
         private DropZone gripZone;
         private GameObject top;
-        public void Construct(Game game, DropZone gripZone)
+
+        public StackPile(GameObject gameObject, Game game, DropZone gripZone, BoardParts parts)
         {
             this.game = game;
             this.gripZone = gripZone;
-        }
-
-        void Start()
-        {
-            var printer = gameObject.AddComponent<CardPrinter>();
-            top = printer.PrintRunnerFacedown("Top of stack");
+            top = parts.Print(gameObject).PrintRunnerFacedown("Top of stack");
             top.transform.SetAsFirstSibling();
             top.transform.rotation *= Quaternion.Euler(0.0f, 0.0f, 90.0f);
             var rect = top.GetComponent<RectTransform>();
@@ -32,6 +27,7 @@ namespace view.gui
                     game,
                     gripZone
                 );
+            game.runner.zones.stack.zone.ObserveCount(gameObject.AddComponent<PileCount>());
         }
 
         void IZoneCountObserver.NotifyCount(int count)

--- a/Assets/Scripts/View/GUI/TrashChoiceScreen.cs
+++ b/Assets/Scripts/View/GUI/TrashChoiceScreen.cs
@@ -19,10 +19,10 @@ namespace view.gui
         private GameObject optionsRow;
         private IDictionary<Card, GameObject> visuals = new Dictionary<Card, GameObject>();
 
-        public TrashChoiceScreen(GameObject board)
+        public TrashChoiceScreen(BoardParts parts)
         {
-            blanket = CreateBlanket(board);
-            subjectRow = CreateSubjectRow(blanket);
+            blanket = CreateBlanket(parts.board);
+            subjectRow = CreateSubjectRow(blanket, parts);
             optionsRow = CreateOptionsRow(blanket);
         }
 
@@ -44,7 +44,7 @@ namespace view.gui
             return blanket;
         }
 
-        private CardPrinter CreateSubjectRow(GameObject blanket)
+        private CardPrinter CreateSubjectRow(GameObject blanket, BoardParts parts)
         {
             var subjectRow = new GameObject("Subject row")
             {
@@ -56,7 +56,7 @@ namespace view.gui
             rectangle.anchorMax = new Vector2(0.9f, 1.0f);
             rectangle.offsetMin = Vector2.zero;
             rectangle.offsetMax = Vector2.zero;
-            return subjectRow.AddComponent<CardPrinter>();
+            return parts.Print(subjectRow);
         }
 
 

--- a/Assets/Scripts/View/GUI/ZoneBox.cs
+++ b/Assets/Scripts/View/GUI/ZoneBox.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using model;
 using model.cards;
 using model.zones;
 using UnityEngine;
@@ -26,24 +25,8 @@ namespace view.gui
 
         void IZoneAdditionObserver.NotifyCardAdded(Card card)
         {
-            var printedCard = Print(card);
+            var printedCard = Printer.Print(card);
             visuals[card] = printedCard;
-        }
-
-        private GameObject Print(Card card)
-        {
-            if (card.Faceup)
-            {
-                return Printer.Print(card);
-            }
-            else if (card.Faction.Side == Side.RUNNER)
-            {
-                return Printer.PrintRunnerFacedown("Facedown");
-            }
-            else
-            {
-                return Printer.PrintCorpFacedown("Facedown");
-            }
         }
 
         void IZoneRemovalObserver.NotifyCardRemoved(Card card)

--- a/Assets/Scripts/View/GUI/ZoneBox.cs
+++ b/Assets/Scripts/View/GUI/ZoneBox.cs
@@ -12,10 +12,10 @@ namespace view.gui
         private CardPrinter Printer;
         private IDictionary<Card, GameObject> visuals = new Dictionary<Card, GameObject>();
 
-        public ZoneBox(GameObject gameObject)
+        public ZoneBox(GameObject gameObject, BoardParts parts)
         {
             this.gameObject = gameObject;
-            Printer = gameObject.AddComponent<CardPrinter>();
+            Printer = parts.Print(gameObject);
         }
 
         public void Represent(Zone zone)


### PR DESCRIPTION
Cards are printed in many places. All go through `CardPrinter`.
So it can wire in the click-listener to a *shared* zoom-in view.
But it was a `MonoBehavior`, added (and so constructed) in many places.
Injecting a shared view would have to be done in every call site.
The compiler wouldn't help catch missed spots, because `Monobehavior`s don't use constructors.

So I refactored many components into plain old objects, with constructor injection.
I also split the `CardPrinter` initialization into stages.
It starts with just the shared state.
Then it can be attached to a local state (gameObject).

Add a rudimentary `CardZoom` GUI proof of concept.
Currently it has the following problems:
- it cannot be closed
- it will reveal facedown cards
- it creates gameobjects, but it never destroys them

Progress on #104.