### PR TITLE
Visualize credit pools as a bunch of tokens

### DIFF
--- a/Assets/Resources/Images/UI/credit.svg
+++ b/Assets/Resources/Images/UI/credit.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+              "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-8 -12 48 88">
+  <path id="credit-outline1" fill="none" stroke="orange" stroke-width="12" stroke-opacity="0.5" d="
+    M 16 0
+    L 32 16
+    L 32 48
+    L 16 64
+    L 0 48
+    L 0 16
+    Z" />
+  <path id="credit-outline2" fill="orange" fill-opacity="0.7" stroke="white" stroke-width="4" d="
+    M 16 0
+    L 32 16
+    L 32 48
+    L 16 64
+    L 0 48
+    L 0 16
+    Z" />
+  <path id="credit-notch" fill="white"  d="
+    M 0 16
+    L 16 32
+    L 16 48
+    L 0 32
+    Z" />
+</svg>

--- a/Assets/Resources/Images/UI/credit.svg.meta
+++ b/Assets/Resources/Images/UI/credit.svg.meta
@@ -1,0 +1,55 @@
+fileFormatVersion: 2
+guid: 14ded5a7c71921141b0312119ba4dce2
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: a57477913897c46af95d590f580878bd, type: 3}
+  svgType: 1
+  texturedSpriteMeshType: 0
+  svgPixelsPerUnit: 200
+  gradientResolution: 64
+  alignment: 0
+  customPivot: {x: 0, y: 0}
+  generatePhysicsShape: 0
+  viewportOptions: 0
+  preserveViewport: 0
+  advancedMode: 0
+  predefinedResolutionIndex: 1
+  targetResolution: 1080
+  resolutionMultiplier: 1
+  stepDistance: 10
+  samplingStepDistance: 100
+  maxCordDeviationEnabled: 0
+  maxCordDeviation: 1
+  maxTangentAngleEnabled: 0
+  maxTangentAngle: 5
+  keepTextureAspectRatio: 1
+  textureSize: 256
+  textureWidth: 256
+  textureHeight: 256
+  wrapMode: 0
+  filterMode: 1
+  sampleCount: 4
+  preserveSVGImageAspect: 0
+  useSVGPixelsPerUnit: 0
+  spriteData:
+    TessellationDetail: 0
+    SpriteRect:
+      name: credit-pathSprite
+      originalName: 
+      pivot: {x: 0.5, y: 0.4998183}
+      alignment: 0
+      border: {x: 0, y: 0, z: 0, w: 0}
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 0
+        width: 44
+        height: 81
+      spriteID: 76191d125811dc846b2a1e7a30110ab0
+      internalID: 0
+    PhysicsOutlines: []

--- a/Assets/Resources/Prefabs.meta
+++ b/Assets/Resources/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6d6bee3cb95cf446afc1c6f976bf082
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/Credit.prefab
+++ b/Assets/Resources/Prefabs/Credit.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3760033668216244476
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6744257487890468150}
+  - component: {fileID: 1839623282570449476}
+  - component: {fileID: 7562516850230756948}
+  m_Layer: 5
+  m_Name: Credit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6744257487890468150
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3760033668216244476}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 32, y: 64}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1839623282570449476
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3760033668216244476}
+  m_CullTransparentMesh: 1
+--- !u!114 &7562516850230756948
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3760033668216244476}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 3286163911610860551, guid: 14ded5a7c71921141b0312119ba4dce2,
+    type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/Resources/Prefabs/Credit.prefab.meta
+++ b/Assets/Resources/Prefabs/Credit.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b2d2297e6ff49df428afe4bf35cb94c4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -195,97 +195,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 19864940}
   m_CullTransparentMesh: 0
---- !u!1 &46655254
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 46655255}
-  - component: {fileID: 46655258}
-  - component: {fileID: 46655257}
-  - component: {fileID: 46655256}
-  m_Layer: 5
-  m_Name: Credits text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &46655255
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 46655254}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1622406200}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &46655256
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 46655254}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: be2fd67db2cf9f54a903610c4fd418f8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &46655257
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 46655254}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: credits
---- !u!222 &46655258
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 46655254}
-  m_CullTransparentMesh: 0
 --- !u!1 &51490138
 GameObject:
   m_ObjectHideFlags: 0
@@ -317,8 +226,8 @@ RectTransform:
   m_Father: {fileID: 477074614}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.3, y: 0}
-  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.3, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -404,7 +313,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.39215687}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -438,13 +347,12 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1965454920}
+  m_Children: []
   m_Father: {fileID: 1758413494}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.4}
-  m_AnchorMax: {x: 0.25, y: 0.6}
+  m_AnchorMax: {x: 0.4, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -520,7 +428,7 @@ RectTransform:
   m_Father: {fileID: 1758413494}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.6}
+  m_AnchorMin: {x: 0.4, y: 0.6}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
@@ -586,7 +494,7 @@ MonoBehaviour:
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1920, y: 1080}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
+  m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
@@ -698,7 +606,7 @@ RectTransform:
   m_Father: {fileID: 477074614}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.8, y: 0}
+  m_AnchorMin: {x: 0.7, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
@@ -906,8 +814,8 @@ RectTransform:
   m_Father: {fileID: 477074614}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.55, y: 0}
-  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchorMin: {x: 0.35, y: 0}
+  m_AnchorMax: {x: 0.65, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
@@ -969,14 +877,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300002, guid: 1b2aadd903d49284782f22c8a8e463de, type: 3}
+  m_Sprite: {fileID: 3286163911610860551, guid: 14ded5a7c71921141b0312119ba4dce2,
+    type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -993,7 +902,7 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1261533424}
-  m_CullTransparentMesh: 0
+  m_CullTransparentMesh: 1
 --- !u!114 &1261533428
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1127,12 +1036,11 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 46655255}
+  m_Children: []
   m_Father: {fileID: 2109041466}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.8}
+  m_AnchorMin: {x: 0, y: 0.55}
   m_AnchorMax: {x: 0.2, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
@@ -1439,99 +1347,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1965454919
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1965454920}
-  - component: {fileID: 1965454922}
-  - component: {fileID: 1965454921}
-  - component: {fileID: 1965454923}
-  m_Layer: 5
-  m_Name: Credits text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1965454920
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1965454919}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 222865691}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.95}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 1}
---- !u!114 &1965454921
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1965454919}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 1
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 'credits
-
-'
---- !u!222 &1965454922
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1965454919}
-  m_CullTransparentMesh: 0
---- !u!114 &1965454923
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1965454919}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: be2fd67db2cf9f54a903610c4fd418f8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1972946644
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/View/GUI/CorpViewConfig.cs
+++ b/Assets/Scripts/View/GUI/CorpViewConfig.cs
@@ -8,7 +8,9 @@ namespace view.gui
         public CorpView Display(Game game, BoardParts parts)
         {
             var zones = game.corp.zones;
-            game.corp.credits.Observe(GameObject.Find("Corp/Credits").AddComponent<CreditSpiral>());
+            var credits = GameObject.Find("Corp/Credits");
+            game.corp.credits.Observe(credits.AddComponent<CreditSpiral>());
+            game.corp.credits.Observe(credits.AddComponent<PileCount>());
             var servers = new ServerRow(GameObject.Find("Servers"), parts, zones);
             var archivesBox = servers.Box(zones.archives);
             archivesBox.Printer.Sideways = true;

--- a/Assets/Scripts/View/GUI/CorpViewConfig.cs
+++ b/Assets/Scripts/View/GUI/CorpViewConfig.cs
@@ -8,7 +8,7 @@ namespace view.gui
         public CorpView Display(Game game, BoardParts parts)
         {
             var zones = game.corp.zones;
-            game.corp.credits.Observe(GameObject.Find("Corp/Credits/Credits text").AddComponent<CreditPoolText>());
+            game.corp.credits.Observe(GameObject.Find("Corp/Credits").AddComponent<CreditSpiral>());
             var servers = new ServerRow(GameObject.Find("Servers"), parts, zones);
             var archivesBox = servers.Box(zones.archives);
             archivesBox.Printer.Sideways = true;

--- a/Assets/Scripts/View/GUI/CreditSpiral.cs
+++ b/Assets/Scripts/View/GUI/CreditSpiral.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using model;
+using UnityEngine;
+
+namespace view.gui
+{
+    public class CreditSpiral : MonoBehaviour, IBalanceObserver
+    {
+        private GameObject creditPrefab;
+        private IList<GameObject> credits = new List<GameObject>();
+        private Spiral spiral = new Spiral();
+
+        void Awake()
+        {
+            creditPrefab = Resources.Load("Prefabs/Credit") as GameObject;
+        }
+
+        void IBalanceObserver.NotifyBalance(int balance)
+        {
+            var diff = balance - credits.Count;
+            if (diff > 0)
+            {
+                for (int i = 0; i < diff; i++)
+                {
+                    AppendHex();
+                }
+            }
+            else
+            {
+                for (int i = 0; i < -diff; i++)
+                {
+                    DropHex();
+                }
+            }
+        }
+
+        private void AppendHex()
+        {
+            var hex = Instantiate(creditPrefab, transform, false);
+            var rect = hex.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.50f, 0.50f);
+            rect.anchorMax = new Vector2(0.50f, 0.50f);
+            rect.anchoredPosition = spiral.PickVector(credits.Count + 1) * 32.0f;
+            credits.Add(hex);
+        }
+
+        private void DropHex()
+        {
+            var last = credits.Last();
+            credits.Remove(last);
+            UnityEngine.Object.Destroy(last);
+        }
+    }
+}

--- a/Assets/Scripts/View/GUI/CreditSpiral.cs
+++ b/Assets/Scripts/View/GUI/CreditSpiral.cs
@@ -2,18 +2,35 @@
 using System.Linq;
 using model;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace view.gui
 {
-    public class CreditSpiral : MonoBehaviour, IBalanceObserver
+    public class CreditSpiral : MonoBehaviour, IBalanceObserver, ILayoutGroup
     {
         private GameObject creditPrefab;
-        private IList<GameObject> credits = new List<GameObject>();
+        private IList<RectTransform> credits = new List<RectTransform>();
         private Spiral spiral = new Spiral();
+        private RectTransform scaler;
 
         void Awake()
         {
             creditPrefab = Resources.Load("Prefabs/Credit") as GameObject;
+            scaler = new GameObject("Scale control").AddComponent<RectTransform>();
+            scaler.SetParent(transform);
+            scaler.anchorMin = Vector2.zero;
+            scaler.anchorMax = Vector2.one;
+            scaler.offsetMin = Vector2.zero;
+            scaler.offsetMax = Vector2.zero;
+            HackInAutoLayout();
+        }
+
+        private void HackInAutoLayout()
+        {
+            var spy = scaler.gameObject.AddComponent<Image>();
+            spy.raycastTarget = false;
+            spy.maskable = false;
+            spy.color = new Color(0, 0, 0, 0);
         }
 
         void IBalanceObserver.NotifyBalance(int balance)
@@ -33,23 +50,80 @@ namespace view.gui
                     DropHex();
                 }
             }
+            Rescale();
         }
 
         private void AppendHex()
         {
-            var hex = Instantiate(creditPrefab, transform, false);
+            var hex = Instantiate(creditPrefab, scaler, false);
             var rect = hex.GetComponent<RectTransform>();
             rect.anchorMin = new Vector2(0.50f, 0.50f);
             rect.anchorMax = new Vector2(0.50f, 0.50f);
             rect.anchoredPosition = spiral.PickVector(credits.Count + 1) * 32.0f;
-            credits.Add(hex);
+            credits.Add(rect);
+        }
+
+        private void Rescale()
+        {
+            if (credits.Count == 0)
+            {
+                return;
+            }
+            var rect = GetComponent<RectTransform>();
+            var container = new Bounds(rect.position, Vector3.zero);
+            var corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+            foreach (var corner in corners)
+            {
+                container.Encapsulate(corner);
+            }
+            var preScaledContent = new Bounds(credits[0].position, Vector3.zero);
+            foreach (var credit in credits)
+            {
+                credit.GetWorldCorners(corners);
+                foreach (var corner in corners)
+                {
+                    preScaledContent.Encapsulate(corner);
+                }
+            }
+
+            var xFactor = container.size.x / preScaledContent.size.x;
+            var yFactor = container.size.y / preScaledContent.size.y;
+            var fitFactor = Mathf.Min(xFactor, yFactor);
+            if (float.IsNaN(fitFactor) || float.IsInfinity(fitFactor) || fitFactor == 0.0f)
+            {
+                return;
+            }
+            var scale = new Vector3(fitFactor, fitFactor, fitFactor);
+            scale.Scale(scaler.localScale);
+            scaler.localScale = scale;
+            var postScaledContent = new Bounds(credits[0].position, Vector3.zero);
+            foreach (var credit in credits)
+            {
+                credit.GetWorldCorners(corners);
+                foreach (var corner in corners)
+                {
+                    postScaledContent.Encapsulate(corner);
+                }
+            }
+            scaler.position += container.center - postScaledContent.center; // calc it from preScaledContent * minFactor
         }
 
         private void DropHex()
         {
             var last = credits.Last();
             credits.Remove(last);
-            UnityEngine.Object.Destroy(last);
+            UnityEngine.Object.Destroy(last.gameObject);
+        }
+
+        void ILayoutController.SetLayoutHorizontal()
+        {
+            Rescale();
+        }
+
+        void ILayoutController.SetLayoutVertical()
+        {
+            Rescale();
         }
     }
 }

--- a/Assets/Scripts/View/GUI/CreditSpiral.cs.meta
+++ b/Assets/Scripts/View/GUI/CreditSpiral.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20084d30a781e4546985f24998c095ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/View/GUI/PileCount.cs
+++ b/Assets/Scripts/View/GUI/PileCount.cs
@@ -1,10 +1,11 @@
-﻿using model.zones;
+﻿using model;
+using model.zones;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 namespace view.gui {
-	public class PileCount : MonoBehaviour, IZoneCountObserver, IPointerEnterHandler, IPointerExitHandler {
+	public class PileCount : MonoBehaviour, IZoneCountObserver, IBalanceObserver, IPointerEnterHandler, IPointerExitHandler {
 		private Text text;
 
 		void Awake() {
@@ -30,6 +31,11 @@ namespace view.gui {
 		void IZoneCountObserver.NotifyCount(int count) {
 			text.text = count.ToString();
 		}
+
+        void IBalanceObserver.NotifyBalance(int balance)
+        {
+            text.text = balance.ToString();
+        }
 
 		void IPointerEnterHandler.OnPointerEnter(PointerEventData eventData) {
 			text.enabled = true;

--- a/Assets/Scripts/View/GUI/RunnerViewConfig.cs
+++ b/Assets/Scripts/View/GUI/RunnerViewConfig.cs
@@ -27,8 +27,7 @@ namespace view.gui
                     game,
                     GameObject.Find("Runner/Right hand/Credits").AddComponent<DropZone>()
                 );
-
-            game.runner.credits.Observe(GameObject.Find("Runner/Right hand/Credits/Credits text").AddComponent<CreditPoolText>());
+            game.runner.credits.Observe(GameObject.Find("Runner/Right hand/Credits").AddComponent<CreditSpiral>());
         }
     }
 }

--- a/Assets/Scripts/View/GUI/RunnerViewConfig.cs
+++ b/Assets/Scripts/View/GUI/RunnerViewConfig.cs
@@ -20,14 +20,16 @@ namespace view.gui
                 serverRow: corpView.serverRow,
                 game: game
             );
+            var credits = GameObject.Find("Runner/Right hand/Credits");
             GameObject.Find("Bank/Credit")
                 .AddComponent<DroppableAbility>()
                 .Represent(
                     game.runner.actionCard.credit,
                     game,
-                    GameObject.Find("Runner/Right hand/Credits").AddComponent<DropZone>()
+                    credits.AddComponent<DropZone>()
                 );
-            game.runner.credits.Observe(GameObject.Find("Runner/Right hand/Credits").AddComponent<CreditSpiral>());
+            game.runner.credits.Observe(credits.AddComponent<CreditSpiral>());
+            game.runner.credits.Observe(credits.AddComponent<PileCount>());
         }
     }
 }

--- a/Assets/Scripts/View/GUI/Spiral.cs
+++ b/Assets/Scripts/View/GUI/Spiral.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace view.gui
+{
+    public class Spiral
+    {
+        private static float HORIZONTAL = 1f / 2f;
+        private static float VERTICAL = 4f / 3f;
+        public static Vector2 R = Vector2.right;
+        public static Vector2 RD = Vector2.right * HORIZONTAL + Vector2.down * VERTICAL;
+        public static Vector2 LD = Vector2.left * HORIZONTAL + Vector2.down * VERTICAL;
+        public static Vector2 L = Vector2.left;
+        public static Vector2 LU = Vector2.left * HORIZONTAL + Vector2.up * VERTICAL;
+        public static Vector2 RU = Vector2.right * HORIZONTAL + Vector2.up * VERTICAL;
+
+        public Vector2 PickVector(int hexIndex)
+        {
+            if (hexIndex == 1)
+            {
+                return Vector2.zero;
+            }
+            var cycle = 1;
+            while (hexIndex > CycleSize(cycle))
+            {
+                hexIndex -= CycleSize(cycle);
+                cycle++;
+            }
+            var cycleStart = LU * (cycle - 1);
+            var withinCycle = YieldVector(cycle).Take(hexIndex - 1).Aggregate(Vector2.zero, (a, b) => a + b);
+            return cycleStart + withinCycle;
+        }
+
+        private IEnumerable<Vector2> YieldVector(int cycle)
+        {
+            for (int i = 0; i < cycle; i++)
+            {
+                yield return R;
+            }
+            for (int i = 0; i < cycle - 1; i++) // the -1 is intentional
+            {
+                yield return RD;
+            }
+            for (int i = 0; i < cycle; i++)
+            {
+                yield return LD;
+            }
+            for (int i = 0; i < cycle; i++)
+            {
+                yield return L;
+            }
+            for (int i = 0; i < cycle; i++)
+            {
+                yield return LU;
+            }
+            for (int i = 0; i < cycle; i++)
+            {
+                yield return RU;
+            }
+        }
+
+        private int CountCycles(int hexIndex)
+        {
+            var cycle = 1;
+            while (hexIndex > CycleSize(cycle))
+            {
+                hexIndex -= CycleSize(cycle);
+                cycle++;
+            }
+            return cycle;
+        }
+
+        private int CycleSize(int cycle) => cycle * 6 - 1;
+    }
+
+}

--- a/Assets/Scripts/View/GUI/Spiral.cs.meta
+++ b/Assets/Scripts/View/GUI/Spiral.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ec555e0d7435d345be16c719b31bec4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/SpiralTest.cs
+++ b/Assets/Tests/SpiralTest.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using UnityEngine;
+using view.gui;
+using static view.gui.Spiral;
+
+namespace tests
+{
+    public class SpiralTest
+    {
+
+        [Test]
+        public void ShouldPickVector()
+        {
+            ShouldPickVector(1, Vector2.zero);
+            ShouldPickVector(2, R);
+            ShouldPickVector(3, R + LD);
+            ShouldPickVector(4, R + LD + L);
+            ShouldPickVector(5, R + LD + L + LU);
+            ShouldPickVector(6, R + LD + L + LU + RU);
+            ShouldPickVector(19, 2 * RU);
+        }
+
+        private void ShouldPickVector(int hexIndex, Vector2 expected)
+        {
+            var spiral = new Spiral();
+            Assert.AreEqual(expected, spiral.PickVector(hexIndex));
+        }
+    }
+}

--- a/Assets/Tests/SpiralTest.cs.meta
+++ b/Assets/Tests/SpiralTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d5d6f688d69a4f449f17e452746e30f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -13,6 +13,7 @@
     "com.unity.textmeshpro": "2.0.1",
     "com.unity.timeline": "1.2.6",
     "com.unity.ugui": "1.0.0",
+    "com.unity.vectorgraphics": "2.0.0-preview.12",
     "com.unity.xr.legacyinputhelpers": "2.1.3",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -165,7 +165,7 @@ PlayerSettings:
   applicationIdentifier:
     Android: com.Dagguh.DataHunt
   buildNumber: {}
-  AndroidBundleVersionCode: 2
+  AndroidBundleVersionCode: 3
   AndroidMinSdkVersion: 19
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1


### PR DESCRIPTION
Left to do:
- scale tokens with resolutions and aspect ratios
- fit the pile in an area - tokens are protruding out of the box
- display a count on hover, like with `PileCount`

![image](https://user-images.githubusercontent.com/1194704/83341842-47dd0180-a2e8-11ea-9626-6134dc56d26e.png)
